### PR TITLE
Implement Recent ESPHome Changes

### DIFF
--- a/HC_ESP_Home_Sensor.yaml
+++ b/HC_ESP_Home_Sensor.yaml
@@ -66,18 +66,18 @@ sensor:
     model: DHT22
     pin: 12
     temperature:
-      name: "ESP Home Sensor Temperature"
+      name: "Temperature"
     #  unit_of_measurement: oC
     #  accuracy_decimals: 1
     humidity:
-      name: "ESP Home Sensor Humidity"
+      name: "Humidity"
     #  unit_of_measurement: RH%
       accuracy_decimals: 1
     update_interval: 60s
 
   # LDR brightness sensor
   - platform: adc
-    name: "ESP Home Sensor Brightness"
+    name: "Brightness"
     icon: "mdi:white-balance-sunny"
     pin: A0
     unit_of_measurement: '%'
@@ -97,7 +97,7 @@ sensor:
 binary_sensor:
   # PIR motion sensor
   - platform: gpio
-    name: "ESP Home Sensor Motion"
+    name: "Motion"
     pin: GPIO5
     device_class: motion
 
@@ -105,7 +105,7 @@ binary_sensor:
 switch:
   # Module LED
   - platform: gpio
-    name: "ESP Home Sensor LED"
+    name: "LED"
     icon: "mdi:led-on"
     pin: GPIO13
     id: led_state

--- a/HC_ESP_Home_Sensor.yaml
+++ b/HC_ESP_Home_Sensor.yaml
@@ -74,7 +74,7 @@ sensor:
       name: "Humidity"
     #  unit_of_measurement: RH%
       accuracy_decimals: 1
-    update_interval: 60s
+    update_interval: 15s
 
   # LDR brightness sensor
   - platform: adc
@@ -93,7 +93,7 @@ sensor:
       #- sliding_window_moving_average:
       #    window_size: 10
       #    send_every: 1
-    update_interval: 60s
+    update_interval: 15s
 
 
 binary_sensor:

--- a/HC_ESP_Home_Sensor.yaml
+++ b/HC_ESP_Home_Sensor.yaml
@@ -16,7 +16,7 @@ esphome:
   # configuration and updates.
   project:
     name: hobbycomponents.HCESP_Home_Sensor
-    version: 1.0.1
+    version: 1.1.0
 
 
 

--- a/HC_ESP_Home_Sensor.yaml
+++ b/HC_ESP_Home_Sensor.yaml
@@ -32,7 +32,7 @@ esp8266:
   board: esp01_1m
 
 # To be able to get logs from the device via serial and api.
-# logger:
+logger:
 
 # Enable Home Assistant API
 api:

--- a/HC_ESP_Home_Sensor.yaml
+++ b/HC_ESP_Home_Sensor.yaml
@@ -63,6 +63,7 @@ captive_portal:
 sensor:
   # DHT22 Temperature & humidity sensor
   - platform: dht
+    id: dht_sensor
     model: DHT22
     pin: 12
     temperature:
@@ -77,6 +78,7 @@ sensor:
 
   # LDR brightness sensor
   - platform: adc
+    id: brightness_sensor
     name: "Brightness"
     icon: "mdi:white-balance-sunny"
     pin: A0
@@ -97,6 +99,7 @@ sensor:
 binary_sensor:
   # PIR motion sensor
   - platform: gpio
+    id: motion_sensor
     name: "Motion"
     pin: GPIO5
     device_class: motion


### PR DESCRIPTION
Hello. I received my device today and am thrilled with it, it's exactly what I've been looking for.

I've created a pull request which fixes a few minor issues, and moves the device closer to the ["Made for ESPHome"](https://esphome.io/guides/made_for_esphome) standard.

One paper-cut issue was the naming of the sensors. It's now possible to just call them "Humidty", "Temeprature" etc. and they will inherit the friendly name defined in `esphome:`. This means if you rename the device in home assistant, the sensors will also now be renamed, whereas before they always had the name "ESP Home Sensor Temperature" etc.

I also increased the update frequency for the sensors to every 15s.

I hope this is of help.